### PR TITLE
Remove unnecessary else statements in script

### DIFF
--- a/root-fs/app/bin/prepare-bluespice
+++ b/root-fs/app/bin/prepare-bluespice
@@ -21,11 +21,9 @@ chown -R 1002:1002 /data/wiki
 if ls /data/database/logs/mariadb-bin.* 1>/dev/null 2>&1; then
   echo "Cleaning up MariaDB binlog files"
   rm -f /data/database/logs/mariadb-bin.*
-else
 fi
 
 if ls /data/database/logs/mysql/mariadb-bin.* 1>/dev/null 2>&1; then
   echo "Cleaning up MariaDB binlog files"
   rm -f /data/database/logs/mysql/mariadb-bin.*
-else
 fi


### PR DESCRIPTION
also fixes sh vs bash interpretation